### PR TITLE
 Updated project description and licensing information

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,4 +1,5 @@
-<h1>ROS package for Schunk WSG-50 Gripper</h1>
+<h1>ROS package for Weiss Robotics WSG 32 Gripper</h1>
+<p>(also distributed as Schunk WSG 32)</p>
 
 <p>Forked from: <a href="https://code.google.com/p/wsg50-ros-pkg">https://code.google.com/p/wsg50-ros-pkg</a></p>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ROS package for Schunk WSG-50 Gripper
+# ROS package for Weiss Robotics WSG 32 Gripper
+(also distributed as Schunk WSG 32)
+
 Forked from: [https://code.google.com/p/wsg50-ros-pkg](https://code.google.com/p/wsg50-ros-pkg)
 
 Modifications of this repository:

--- a/wsg_32_driver/include/wsg_32/char.h
+++ b/wsg_32_driver/include/wsg_32/char.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	16.09.2011
  *  
  *  
  *  @section char.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/checksum.h
+++ b/wsg_32_driver/include/wsg_32/checksum.h
@@ -16,9 +16,29 @@
  *  
  *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/cmd.h
+++ b/wsg_32_driver/include/wsg_32/cmd.h
@@ -8,17 +8,37 @@
  *  @brief
  *  Command abstraction layer (Header file)
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	20.07.2011
  *  
  *  
  *  @section cmd.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/common.h
+++ b/wsg_32_driver/include/wsg_32/common.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section common.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/functions.h
+++ b/wsg_32_driver/include/wsg_32/functions.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	30.04.2012
  *  
  *  
  *  @section testing.h_copyright Copyright
  *  
- *  Copyright 2012 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2012 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/interface.h
+++ b/wsg_32_driver/include/wsg_32/interface.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section interface.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/msg.h
+++ b/wsg_32_driver/include/wsg_32/msg.h
@@ -8,17 +8,37 @@
  *  @brief
  *  Raw send and receive functions for command messages (Header file)
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	19.07.2011
  *  
  *  
  *  @section msg.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/serial.h
+++ b/wsg_32_driver/include/wsg_32/serial.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	08.07.2011
  *  
  *  
  *  @section serial.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/tcp.h
+++ b/wsg_32_driver/include/wsg_32/tcp.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	08.07.2011
  *  
  *  
  *  @section tcp.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/include/wsg_32/udp.h
+++ b/wsg_32_driver/include/wsg_32/udp.h
@@ -8,17 +8,37 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section udp.h_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
- *  The distribution of this code and excerpts thereof, neither in 
- *  source nor in any binary form, is prohibited, except you have our 
- *  explicit and written permission to do so.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  */
 //======================================================================

--- a/wsg_32_driver/src/checksum.cpp
+++ b/wsg_32_driver/src/checksum.cpp
@@ -6,16 +6,16 @@
  *  @section checksum.c_general General file information
  *
  *  @brief
- *  Checksum functions. Taken from wrOS.
+ *  Checksum functions
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	19.07.2011
  *  
  *  
  *  @section checksum.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -25,9 +25,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/cmd.c
+++ b/wsg_32_driver/src/cmd.c
@@ -8,13 +8,13 @@
  *  @brief
  *  Command abstraction layer
  *
- *  @author wolfer
+ *  @author 	Steffen Wolfer
  *  @date	20.07.2011
  *  
  *  
  *  @section cmd.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/common.cpp
+++ b/wsg_32_driver/src/common.cpp
@@ -8,13 +8,13 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author 	Steffen Wolfer
  *  @date	19.07.2011
  *  
  *  
  *  @section common.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/functions.cpp
+++ b/wsg_32_driver/src/functions.cpp
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/functions_can.cpp
+++ b/wsg_32_driver/src/functions_can.cpp
@@ -3,29 +3,29 @@
  * Copyright (c) 2012, Robotnik Automation, SLL
  * All rights reserved.
  *  
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
  *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  *
  * \date   14.09.2012
  * \author Marc Benetó (mbeneto@robotnik.es)

--- a/wsg_32_driver/src/interface.cpp
+++ b/wsg_32_driver/src/interface.cpp
@@ -8,13 +8,13 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section interface.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/msg.c
+++ b/wsg_32_driver/src/msg.c
@@ -8,13 +8,13 @@
  *  @brief
  *  Raw send and receive functions for command messages
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section msg.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/serial.c
+++ b/wsg_32_driver/src/serial.c
@@ -8,13 +8,13 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	08.07.2011
  *  
  *  
  *  @section serial.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/tcp.c
+++ b/wsg_32_driver/src/tcp.c
@@ -8,13 +8,13 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	08.07.2011
  *  
  *  
  *  @section tcp.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/wsg_32_driver/src/udp.c
+++ b/wsg_32_driver/src/udp.c
@@ -8,13 +8,13 @@
  *  @brief
  *  
  *
- *  @author wolfer
+ *  @author	Steffen Wolfer
  *  @date	07.07.2011
  *  
  *  
  *  @section udp.c_copyright Copyright
  *  
- *  Copyright 2011 Weiss Robotics, D-71636 Ludwigsburg, Germany
+ *  Copyright 2011 Weiss Robotics, D-71640 Ludwigsburg, Germany
  *  
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -24,9 +24,9 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the and Weiss Robotics GmbH nor the names of its 
- *       contributors may be used to endorse or promote products derived from
- *	 this software without specific prior written permission.
+ *     * Neither the name of the company Weiss Robotics GmbH & Co. KG nor the 
+ *       names of its contributors may be used to endorse or promote products
+ *	 derived from this software without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
Added full name of original author (changed wolfer to Steffen Wolfer), updated zip code of company's address (71636 to 71640) in all C/C++ source files originally written by Weiss Robotics. Changed copyright notice in C/C++ header files written by Weiss Robotics to same BSD style license as in source files.